### PR TITLE
Adding a PEL message entry into message_registry.json file

### DIFF
--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -5749,6 +5749,28 @@
                 "Description": "Host failed to complete the power off gracefully within the timeout.",
                 "Message": "Host failed to complete the power off gracefully within the timeout."
             }
+        },
+        {
+            "Name": "xyz.openbmc_project.Dump.Error.Invalidate",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x6000",
+            "Severity": "predictive",
+            "SRC": {
+                "ReasonCode": "0x6025",
+                "Words6To9": {}
+            },
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "bmc_code" }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "Dump has been deleted/offloaded",
+                "Message": "BMC/System/Resource dump has been deleted/offloaded"
+            }
         }
     ]
 }


### PR DESCRIPTION
Adding a PEL entry into message_registry.json file for dump delete.
Default severity is informational and can be overwritten by caller
